### PR TITLE
Default to a randomly-assigned port for the dat swarm.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (archiver, opts) {
   opts.http = opts.http || true
 
   // Dat Swarm options
-  opts.datPort = opts.datPort || 3282
+  opts.datPort = opts.datPort || false
   opts.tcp = opts.tcp || true
   opts.utp = opts.utp || true
 
@@ -77,7 +77,10 @@ function createSwarm (archiver, opts) {
       clearTimeout(timeout)
     })
   })
-  if (!opts.dontShare) swarm.listen(opts.datPort)
+  if (!opts.dontShare) {
+    if (opts.datPort) swarm.listen(opts.datPort)
+    else swarm.listen()
+  }
 
   archiver.changes(function (err, feed) {
     if (err) throw err


### PR DESCRIPTION
For some reason, in hypercloud, I experienced cases where traffic
was not making its way over the link layer (afaict). It appears
that randomizing the port solved it. Not at all sure why, yet.

This PR makes the default port random.